### PR TITLE
feat: best deltaR match

### DIFF
--- a/plugins/UnprefirableAnalyzer.cc
+++ b/plugins/UnprefirableAnalyzer.cc
@@ -289,18 +289,31 @@ bool checkMatchBX(const RecoJet& recojet, const L1JetCollection& l1jetcollection
 
   bool match = false;
 
+  float minDeltaR = 999.0;
+  float matchedPt = 0.0;
+  float matchedEta = 0.0;
+  float matchedPhi = 0.0;
+
   for (auto it = l1jetcollection.begin(bx); it!=l1jetcollection.end(bx); it++){
     // check if match
-    if(deltaR(it, recojet)<0.4 && recojet.pt()>30) {
+    float currentDeltaR = deltaR(it, recojet);
+    if(currentDeltaR<0.4 && recojet.pt()>30) {
       match = true;
-      nbx->Fill(bx);
-      h_jetet->Fill(recojet.pt());
-      h_jeteta->Fill(recojet.eta());
-      h_jetetaphi->Fill(recojet.eta(), recojet.phi());
-      h_jetetaphi_on->Fill(it->eta(),it->phi());
-      h_jeteres->Fill(recojet.pt()/it->pt());
-      break;
+      if (currentDeltaR < minDeltaR){
+        minDeltaR = currentDeltaR;
+        matchedPt = it->pt();
+        matchedEta = it->eta();
+        matchedPhi = it->phi();
+      }
     }
+  }
+
+  if(match){
+    nbx->Fill(bx);
+    h_jetet->Fill(recojet.pt());
+    h_jetetaphi->Fill(recojet.eta(), recojet.phi());
+    h_jetetaphi_on->Fill(matchedEta, matchedPhi);
+    h_jeteres->Fill(matchedPt/recojet.pt());
   }
 
   return match;

--- a/plugins/UnprefirableAnalyzer.cc
+++ b/plugins/UnprefirableAnalyzer.cc
@@ -287,36 +287,33 @@ template <typename RecoJet, typename L1JetCollection>
 bool checkMatchBX(const RecoJet& recojet, const L1JetCollection& l1jetcollection, int bx, 
                   TH1I* nbx, TH1F* h_jetet, TH1F* h_jeteta, TH2F* h_jetetaphi, TH2F* h_jetetaphi_on, TH1F* h_jeteres) {
 
-  bool match = false;
-
   float minDeltaR = 999.0;
   float matchedPt = 0.0;
   float matchedEta = 0.0;
   float matchedPhi = 0.0;
 
   for (auto it = l1jetcollection.begin(bx); it!=l1jetcollection.end(bx); it++){
-    // check if match
+    // check if deltaR value is smallest so far (finds best match if there is one)
     float currentDeltaR = deltaR(it, recojet);
-    if(currentDeltaR<0.4 && recojet.pt()>30) {
-      match = true;
-      if (currentDeltaR < minDeltaR){
-        minDeltaR = currentDeltaR;
-        matchedPt = it->pt();
-        matchedEta = it->eta();
-        matchedPhi = it->phi();
-      }
+    if(currentDeltaR<minDeltaR && recojet.pt()>30) {
+      minDeltaR = currentDeltaR;
+      matchedPt = it->pt();
+      matchedEta = it->eta();
+      matchedPhi = it->phi();
     }
   }
 
-  if(match){
+  if(minDeltaR < 0.4){
     nbx->Fill(bx);
     h_jetet->Fill(recojet.pt());
     h_jetetaphi->Fill(recojet.eta(), recojet.phi());
     h_jetetaphi_on->Fill(matchedEta, matchedPhi);
     h_jeteres->Fill(matchedPt/recojet.pt());
+
+    return true; // true = match found
   }
 
-  return match;
+  return false; // no match found
 }
 
 // ------------ method called for each event  ------------

--- a/python/prefiring_plots.py
+++ b/python/prefiring_plots.py
@@ -446,7 +446,7 @@ def main(file_path, out_dir):
     JetEResbx0_u.SetLineColor(2)
     JetEResbx0_u.SetMarkerColor(2)
     JetEResbx0_u.SetMarkerStyle(47)
-    JetEResbx0_u.GetXaxis().SetTitle("Offline Jet p_{T} / Online Jet p_{T}")
+    JetEResbx0_u.GetXaxis().SetTitle("Online Jet p_{T} / Offline Jet p_{T}")
     JetEResbx0_u.GetYaxis().SetTitle("a.u.")
     JetEResbx0_u.SetStats(False)
     JetEResbx0_u.SetMaximum(1e2)


### PR DESCRIPTION
Before, the deltaR matching accepted the first online jet which had a deltaR < 0.4. This changes the code to find the best deltaR match instead of the first one. 

I also fix the jet pt resolution histogram filling to use the offline jet as the denominator